### PR TITLE
Change to column-major loops and removing submodules

### DIFF
--- a/src/SOH.jl
+++ b/src/SOH.jl
@@ -7,14 +7,6 @@ include("run.jl")
 include("scheme.jl")
 include("toolbox.jl")
 
-using .BoundaryConditions
-using .Flux
-using .Init
-using .PlotSave
-using .Run
-using .Scheme
-using .ToolBox
-
 export boundary_conditions_xy!, boundary_conditions_ρuv!
 export flux_x
 export random_init, quadratic_potential_force, flat_quadratic_potential_force
@@ -25,4 +17,4 @@ export make_new_dir, coefficients_Vicsek, nice_float2string
 
 
 
-end     #module 
+end     #module

--- a/src/boundary_conditions.jl
+++ b/src/boundary_conditions.jl
@@ -1,7 +1,3 @@
-"""Contains the functions to apply boundary conditions and define classical the exterior forces """
-module BoundaryConditions
-export boundary_conditions_xy!, boundary_conditions_ρuv!
-
 """
     boundary_conditions_x!(density,bcond_x)
 
@@ -25,7 +21,7 @@ function boundary_conditions_x!(density,bcond_x)
 end
 
 """
-    boundary_conditions_y!(density,bcond_y) 
+    boundary_conditions_y!(density,bcond_y)
 
 Apply the boundary conditions `bcond_y` on the y-axis of the matrix `density`.
 Currently, only the boundary conditions `"periodic"`, `"Neumann"` and `"reflecting"` are implemented.
@@ -49,7 +45,7 @@ end
     boundary_conditions_xy!(density,bcond_x,bcond_y)
 
 Apply successively the functions `boundary_conditions_x!` and `boundary_conditions_x!` to
-the matrix `density`. 
+the matrix `density`.
 """
 function boundary_conditions_xy!(density,bcond_x,bcond_y)
     boundary_conditions_x!(density,bcond_x)
@@ -59,7 +55,7 @@ end
 """
     boundary_conditions_ρuv!(ρ,u,v,bcond_x,bcond_y)
 
-Apply the boundary conditions to the data `(ρ,u,v)`. 
+Apply the boundary conditions to the data `(ρ,u,v)`.
 """
 function boundary_conditions_ρuv!(ρ,u,v,bcond_x,bcond_y)
     if bcond_x == "periodic" || bcond_x == "Neumann"
@@ -86,5 +82,3 @@ function boundary_conditions_ρuv!(ρ,u,v,bcond_x,bcond_y)
         ArgumentError("Boundary condition not defined!")
     end
 end
-
-end    #module

--- a/src/flux.jl
+++ b/src/flux.jl
@@ -1,11 +1,8 @@
-module Flux
-export flux_x
-
 """
-    eigenvalues_Roe(u,c1,c2,λ)  
+    eigenvalues_Roe(u,c1,c2,λ)
 
 The eigenvalues of the Roe matrix with a 1D velocity `u` are c₂u, c₂u + √Δ and c₂u - √Δ
-with the discriminant Δ = λc₁ - c₂(c₁-c₂)u. 
+with the discriminant Δ = λc₁ - c₂(c₁-c₂)u.
 """
 function eigenvalues_Roe(u,c1,c2,λ)
     Δ = (c2^2 - c1*c2) * u^2 + λ*c1
@@ -19,20 +16,20 @@ end
     abs_Roe_matrix(ρl,ρr,ul,ur,vl,vr,c1,c2,λ)
 
 Return the absolute value of the Roe matrix for the 1D Riemannn problem with respective left and right densities
-`(ρl,ul,vl)` and `(ρr,ur,vr)`. The eigenvalues are increased to avoid sonic rarefaction wave (LLF method).       
+`(ρl,ul,vl)` and `(ρr,ur,vr)`. The eigenvalues are increased to avoid sonic rarefaction wave (LLF method).
 """
 function abs_Roe_matrix(ρl,ρr,ul,ur,vl,vr,c1,c2,λ)
-    
+
     #### Roe average
     um = (sqrt(ρl)*ul + sqrt(ρr)*ur) / (sqrt(ρl) + sqrt(ρr))
     vm = (sqrt(ρl)*vl + sqrt(ρr)*vr) / (sqrt(ρl) + sqrt(ρr))
-    
+
     #### Eigenvalues and eigenvectors
     eval_p, eval_m, eval_0 = eigenvalues_Roe(um,c1,c1,λ)
     z_p = (c1*c2*um*vm - c2*vm*eval_p) / (c2*um - eval_p)
     z_m = (c1*c2*um*vm - c2*vm*eval_m) / (c2*um - eval_m)
     detP = c1 * (eval_m - eval_p)
-    
+
     #### Increase the eigenvalues
     eval_l = eigenvalues_Roe(ul,c1,c2,λ)
     eval_r = eigenvalues_Roe(ur,c1,c2,λ)
@@ -41,11 +38,11 @@ function abs_Roe_matrix(ρl,ρr,ul,ur,vl,vr,c1,c2,λ)
     eval_0_fix = max(abs(eval_l[3]),abs(eval_r[3]))
 
     #### Compute Roe matrix A = P*D*P^{-1}
-    a11 = c1*(eval_p_fix*eval_m - eval_m_fix*eval_p)/detP  
+    a11 = c1*(eval_p_fix*eval_m - eval_m_fix*eval_p)/detP
     a12 = c1^2*(eval_m_fix - eval_p_fix)/detP
     a13 = 0.
-    a21 = eval_m*eval_p*(eval_p_fix - eval_m_fix)/detP 
-    a22 = c1*(eval_m_fix*eval_m - eval_p_fix*eval_p)/detP 
+    a21 = eval_m*eval_p*(eval_p_fix - eval_m_fix)/detP
+    a22 = c1*(eval_m_fix*eval_m - eval_p_fix*eval_p)/detP
     a23 = 0.
     a31 = (-eval_m_fix*eval_p*z_m + eval_p_fix*eval_m*z_p + eval_0_fix*(eval_p*z_m - eval_m*z_p))/detP
     a32 = c1*(eval_m_fix*z_m - eval_p_fix*z_p + eval_0_fix*(z_p - z_m))/detP
@@ -56,8 +53,8 @@ end
 """
     flux_x(ρl,ρr,ul,ur,vl,vr,c1,c2,λ,method)
 
-Return the flux along the x-axis for the 1D Riemannian problem given by the respective left and right 
-densities `(ρl,ul,vl)` and `(ρr,ur,vr)`. The chosen method `method` can be either `"Roe"` or `"HLLE"`.  
+Return the flux along the x-axis for the 1D Riemannian problem given by the respective left and right
+densities `(ρl,ul,vl)` and `(ρr,ur,vr)`. The chosen method `method` can be either `"Roe"` or `"HLLE"`.
 """
 function flux_x(ρl,ρr,ul,ur,vl,vr,c1,c2,λ,method)
     if ρl<1e-9 && ρr<1e-9
@@ -82,18 +79,13 @@ function flux_x(ρl,ρr,ul,ur,vl,vr,c1,c2,λ,method)
         s_lm = min(s_l,0.)
         s_rp = max(s_r,0.)
 
-        f_l = (c1*ρl*ul, c2*ρl*ul^2 + λ*ρl, c2*ρl*ul*vl)    
+        f_l = (c1*ρl*ul, c2*ρl*ul^2 + λ*ρl, c2*ρl*ul*vl)
         f_r = (c1*ρr*ur, c2*ρr*ur^2 + λ*ρr, c2*ρr*ur*vr)
         U_l = (ρl,ρl*ul,ρl*vl)
         U_r = (ρr,ρr*ur,ρr*vr)
         return ((s_rp.*f_l .- s_lm.*f_r) .+ (s_rp*s_lm) .* (U_r .- U_l)) ./ (s_rp - s_lm)
-    else 
+    else
         error("Method not defined!")
     end
 
 end
-
-
-
-
-end    #module

--- a/src/init.jl
+++ b/src/init.jl
@@ -1,9 +1,3 @@
-module Init
-export random_init, quadratic_potential_force, flat_quadratic_potential_force
-
-include("boundary_conditions.jl")
-using .BoundaryConditions
-
 """
     random_init(
         ncellx,ncelly,
@@ -14,8 +8,8 @@ using .BoundaryConditions
 
 Sample a random data `(ρ,u,v)` of size `(ncellx+2)*(ncelly+2)`. The density `ρ` is sampled
 uniformly around `mean_ρ` in an interval of size `range_ρ`. The velocity component `u` and
-`v` are respectively given by `cos(θ)` and `sin(θ)` where `θ` is sampled uniformly around 
-`mean_θ` in an interval of size `range_θ`. Boundary conditions are then applied. 
+`v` are respectively given by `cos(θ)` and `sin(θ)` where `θ` is sampled uniformly around
+`mean_θ` in an interval of size `range_θ`. Boundary conditions are then applied.
 """
 function random_init(
     ncellx,ncelly,
@@ -34,10 +28,10 @@ end
 """
     quadratic_potential_force(ncellx,ncelly,Δx,Δy,C)
 
-Return the components `Fx` and `Fy` of the force exerted by the quadratic radial 
+Return the components `Fx` and `Fy` of the force exerted by the quadratic radial
 potential V(r) = Cr²/2 centered around the midpoint of the box `[0,Lx]*[0,Ly]`
 where `Lx = ncellx * Δx` and `Ly = ncelly * Δy`. For convenience, the outputs `Fx` and `Fy` are
-matrices of size `(ncellx+2)*(ncelly+2)` with zeros on the boundary. 
+matrices of size `(ncellx+2)*(ncelly+2)` with zeros on the boundary.
 """
 function quadratic_potential_force(ncellx,ncelly,Δx,Δy,C)
     Fx = zeros(ncellx+2,ncelly+2)
@@ -59,11 +53,11 @@ end
 """
     flat_quadratic_potential_force(ncellx,ncelly,Δx,Δy,r0,C)
 
-Return the components `Fx` and `Fy` of the force exerted by the quadratic radial 
+Return the components `Fx` and `Fy` of the force exerted by the quadratic radial
 potential defined by V(r) = Cr²/2 for r>r0 and V(r)=0 otherwise,
-centered around the midpoint of the box `[0,Lx]*[0,Ly]` where `Lx = ncellx * Δx` 
+centered around the midpoint of the box `[0,Lx]*[0,Ly]` where `Lx = ncellx * Δx`
 and `Ly = ncelly * Δy`. For convenience, the outputs `Fx` and `Fy` are
-matrices of size `(ncellx+2)*(ncelly+2)` with zeros on the boundary. 
+matrices of size `(ncellx+2)*(ncelly+2)` with zeros on the boundary.
 """
 function flat_quadratic_potential_force(ncellx,ncelly,Δx,Δy,r0,C)
     Fx = zeros(ncellx+2,ncelly+2)
@@ -84,6 +78,4 @@ function flat_quadratic_potential_force(ncellx,ncelly,Δx,Δy,r0,C)
         end
     end
     return Fx, Fy
-end
-
 end

--- a/src/plot_save.jl
+++ b/src/plot_save.jl
@@ -1,25 +1,23 @@
-module PlotSave
 using CairoMakie, ProgressMeter, Statistics
-export plot_rhoUV, update_plot!, save_data!, radial_density
 
 """
     plot_rhoUV(
         ρ,u,v,
         Δx,Δy,
         range,
-        save_plot=true,save_video=false,dir_name=pwd(),file_name="0.png"; 
+        save_plot=true,save_video=false,dir_name=pwd(),file_name="0.png";
         theme="dark", resolution=(800,600),arrow_step=20,fps=40,kwargs...
     )
 
 Return the figure, axes, heatmap and arrows associated to the density `ρ` and velocity field
-`(u,v)`. The plot is saved in the directory `dir_name` in the file `file_name`. Two themes 
-are available, either `"dark"` (default) or `"light"`. 
+`(u,v)`. The plot is saved in the directory `dir_name` in the file `file_name`. Two themes
+are available, either `"dark"` (default) or `"light"`.
 """
 function plot_rhoUV(
     ρ,u,v,
     Δx,Δy,
     range,
-    save_plot=true,save_video=false,dir_name=pwd(),file_name="0.png"; 
+    save_plot=true,save_video=false,dir_name=pwd(),file_name="0.png";
     theme="dark", resolution=(800,600),arrow_step=20,fps=40,kwargs...
 )
     if theme == "dark"
@@ -76,7 +74,7 @@ end
 """
     update_plot!(fig,ax,hm,arrows,ρ,u,v,title,dir_name,file_name,save_plot=true,stream=nothing)
 
-Update a plot created with the function `plot_rhoUV` and save it. 
+Update a plot created with the function `plot_rhoUV` and save it.
 """
 function update_plot!(fig,ax,hm,arrows,ρ,u,v,title,dir_name,file_name,save_plot=true,stream=nothing)
     ncellx = size(ρ)[1] - 2
@@ -105,7 +103,7 @@ end
         ρ,u,v,
         dir_name,file_name;key="data")
 
-Update the dictionary `data` with the values `(ρ,u,v)` and save it. 
+Update the dictionary `data` with the values `(ρ,u,v)` and save it.
 """
 function save_data!(
     data,
@@ -120,9 +118,9 @@ end
 """
     radial_density(ρ,Δx,Δy,K=400)
 
-Compute the radial density as the mean of `ρ` in `K` annuli of 
-equal lengths and evenly spread radii between 0 and the maximal 
-radius in the box. Return the vector of radii and the radial density. 
+Compute the radial density as the mean of `ρ` in `K` annuli of
+equal lengths and evenly spread radii between 0 and the maximal
+radius in the box. Return the vector of radii and the radial density.
 """
 function radial_density(ρ,Δx,Δy,K=400)
     ncellx = size(ρ)[1] - 2
@@ -150,6 +148,3 @@ function radial_density(ρ,Δx,Δy,K=400)
     end
     return r, rho_r
 end
-
-end    #module
-

--- a/src/run.jl
+++ b/src/run.jl
@@ -175,11 +175,15 @@ function run!(
     #============ The big loop =============================================================#
     #=======================================================================================#
 
+    flux_ρ = zeros(ncellx + 1, ncelly + 1)
+    flux_u = zeros(ncellx + 1, ncelly + 1)
+    flux_v = zeros(ncellx + 1, ncelly + 1)
+
     println("Run the simulation...\n")
     ntime = floor(Int, final_time / Δt)
     p = Progress(ntime)
     for itime in 1:ntime
-        scheme_iter!(ρ,u,v,Δx,Δy,Δt,c1,c2,λ,bcond_x,bcond_y,Fx,Fy,method)
+        scheme_iter!(ρ,u,v,Δx,Δy,Δt,c1,c2,λ,bcond_x,bcond_y,Fx,Fy,flux_ρ,flux_u,flux_v,method)
         if should_save
             if itime%save_step == 0
                 save_data!(data,ρ,u,v,data_dir,"data_$itime.jld2",key="iter_$itime")

--- a/src/run.jl
+++ b/src/run.jl
@@ -1,15 +1,4 @@
-"""Contains the main function to run a simulation."""
-module Run
-export run!
-
-include("scheme.jl")
-include("plot_save.jl")
-include("toolbox.jl")
 using JLD2, Dates, ProgressMeter
-using .Scheme
-using .PlotSave
-using .ToolBox
-
 """
     run!(
         ρ,u,v;
@@ -28,18 +17,18 @@ using .ToolBox
     )
 
 Run a simulation of the SOH system starting from the data `(ρ,u,v)`. The domain
-grid has the following structure. 
+grid has the following structure.
 
 ```
 |------- |----------------|---------------|----------------------|--------|
-| ghost  |    ghost       |       ...     |    ghost             | ghost  |     
+| ghost  |    ghost       |       ...     |    ghost             | ghost  |
 |--------║================|===============|======================║--------|
 | ghost  ║  (2,ncelly+1)  |      ...      | (ncellx+1,ncelly+1)  ║ ghost  |
 |--------║----------------|---------------|----------------------║--------|
 | ghost  ║  (2,ncelly)    |      ...      | (ncellx+1,ncelly)    ║ ghost  |
 |--------║----------------|---------------|----------------------║--------|
 |        ║                |               |                      ║        |
-|--------║----------------|---------------|----------------------║--------|   
+|--------║----------------|---------------|----------------------║--------|
 | ghost  ║    (2,3)       |      ...      |   (ncellx+1,3)       ║ ghost  |
 |--------║----------------|---------------|----------------------║--------|
 | ghost  ║    (2,2)       |      ...      |   (ncellx+1,2)       ║ ghost  |
@@ -47,8 +36,8 @@ grid has the following structure.
 | ghost  |    ghost       |      ...      |    ghost             | ghost  |
 |--------|----------------|---------------|----------------------|--------|
 ````
-  
-The ghost cells (first and last column and rows) are used for the boundary 
+
+The ghost cells (first and last column and rows) are used for the boundary
 conditions.
 
 # Arguments
@@ -57,11 +46,11 @@ conditions.
 - `v` -- y-coordinate of the velocity (matrix of size `ncellx*ncelly`)
 - `Lx` -- length of the domain along the x-axis
 - `Ly` -- length of the domain along the y-axis
-- `Δt` -- time-step 
+- `Δt` -- time-step
 - `c1` -- coefficient c1
 - `c2` -- coefficient c1
 - `λ` -- coefficient λ
-- `final_time` -- final time of the simulation 
+- `final_time` -- final time of the simulation
 - `bcond_x` -- (optional, default : `"periodic"`) boundary condition along the x-axis
 - `bcond_y` -- (optional, default : `"periodic"`) boundary condition along the y-axis
 - `Fx` -- (optional, default : `nothing`) if specified, x-coordinate of the exterior force
@@ -70,7 +59,7 @@ conditions.
 - `simu` -- (optional, default : `"simu"`) name of the simulation directory
 - `should_save` -- (optional, default : `false`) flag for saving the data (ρ,u,v)
 - `save_step` -- (optional, default : `1`) number of iterations between two saved data
-- `should_plot` -- (optional, default : `false`) flag for plotting and saving the heatmap 
+- `should_plot` -- (optional, default : `false`) flag for plotting and saving the heatmap
 - `plot_step` -- (optional, default : `1`) number of iterations between two saved plots
 - `save_video` -- (optional, default : `false`) flag for saving a video
 - `fps` -- (optional, default : `40`) frame per seconds
@@ -104,10 +93,10 @@ function run!(
         :Lx => Lx, :Ly => Ly, :ncellx => ncellx, :ncelly => ncelly,
         :Δx => Δx, :Δy => Δy, :Δt => Δt,
         :c1 => c1, :c2 => c2, :λ => λ, :CFL => c1 * Δt/Δx * sqrt(λ/(c1-c2)),
-        :final_time => final_time, 
-        :bcond_x => bcond_x, :bcond_y => bcond_y, 
-        :Fx => Fx, :Fy => Fy, 
-        :method => method, 
+        :final_time => final_time,
+        :bcond_x => bcond_x, :bcond_y => bcond_y,
+        :Fx => Fx, :Fy => Fy,
+        :method => method,
         :date => string(Dates.now())
     )
 
@@ -205,7 +194,7 @@ function run!(
                     update_plot!(fig,ax,hm,arrows,ρ,u,v,"time=$round_time",plot_dir,"$itime.png")
                 end
             end
-        end   
+        end
         next!(p)
     end
 
@@ -230,6 +219,3 @@ function run!(
 
 
 end
-
-
-end    #module

--- a/src/scheme.jl
+++ b/src/scheme.jl
@@ -65,8 +65,8 @@ function scheme_iter!(
     flux_ρ = zeros(ncellx + 1, ncelly)
     flux_u = zeros(ncellx + 1, ncelly)
     flux_v = zeros(ncellx + 1, ncelly)
-    for i in 1:(ncellx+1)
-        for j in 1:ncelly
+    @inbounds for j in 1:ncelly
+        @simd for i in 1:(ncellx+1)
             F = flux_x(
                 ρ[i,j+1],ρ[i+1,j+1],
                 u[i,j+1],u[i+1,j+1],
@@ -81,8 +81,8 @@ function scheme_iter!(
 
     #----------------------- Update ------------------------------------------------#
 
-    for i in 2:(ncellx+1)
-        for j in 2:(ncelly+1)
+    @inbounds for j in 2:(ncelly+1)
+        for i in 2:(ncellx+1)
 
             #------ 2. Conservative part -------------------------------------------#
             U = (ρ[i,j] - (Δt/Δx) * (flux_ρ[i, j-1] - flux_ρ[i-1, j-1]),
@@ -132,8 +132,8 @@ function scheme_iter!(
     flux_ρ = zeros(ncellx, ncelly + 1)
     flux_u = zeros(ncellx, ncelly + 1)
     flux_v = zeros(ncellx, ncelly + 1)
-    for i in 1:ncellx
-        for j in 1:(ncelly+1)
+    @inbounds for j in 1:(ncelly+1)
+        @simd for i in 1:ncellx
             F = flux_x(
                 ρ[i+1,j],ρ[i+1,j+1],
                 v[i+1,j],v[i+1,j+1],
@@ -147,8 +147,8 @@ function scheme_iter!(
     end
 
     #----------------------- Update ------------------------------------------------#
-    for i in 2:(ncellx+1)
-        for j in 2:(ncelly+1)
+    @inbounds for j in 2:(ncelly+1)
+        @simd for i in 2:(ncellx+1)
 
             #------ 2. Conservative part -------------------------------------------#
             U = (ρ[i,j] - (Δt/Δy) * (flux_ρ[i-1, j] - flux_ρ[i-1, j-1]),

--- a/src/scheme.jl
+++ b/src/scheme.jl
@@ -41,6 +41,7 @@ function scheme_iter!(
     c1,c2,λ,
     bcond_x,bcond_y,
     Fx,Fy,
+    flux_ρ, flux_u, flux_v,
     method
 )
     ncellx = size(ρ)[1] - 2
@@ -62,9 +63,6 @@ function scheme_iter!(
 
     #----------------------- 1. Compute the flux -----------------------------------#
 
-    flux_ρ = zeros(ncellx + 1, ncelly)
-    flux_u = zeros(ncellx + 1, ncelly)
-    flux_v = zeros(ncellx + 1, ncelly)
     @inbounds for j in 1:ncelly
         @simd for i in 1:(ncellx+1)
             F = flux_x(
@@ -129,9 +127,6 @@ function scheme_iter!(
     # Note: Change basis (u,v) -> (v,-u) in order to use the same function `flux_x`
     #-------------------------------------------------------------------------------#
 
-    flux_ρ = zeros(ncellx, ncelly + 1)
-    flux_u = zeros(ncellx, ncelly + 1)
-    flux_v = zeros(ncellx, ncelly + 1)
     @inbounds for j in 1:(ncelly+1)
         @simd for i in 1:ncellx
             F = flux_x(
@@ -215,8 +210,8 @@ with C_0 = tan((θ(0)-ψ)/2) and F = |F|(cos(ψ),sin(ψ))ᵀ.
 function scheme_potential!(u,v,Fx,Fy,Δt,λ)
     ncellx = size(u)[1] - 2
     ncelly = size(u)[2] - 2
-    for i in 2:ncellx+1
-        for j in 2:ncelly+1
+    @inbounds for j in 2:ncelly+1
+        for i in 2:ncellx+1
             normF = sqrt(Fx[i,j]^2 + Fy[i,j]^2)
             if normF > 1e-9
                 θ0 = atan(v[i,j],u[i,j])

--- a/src/toolbox.jl
+++ b/src/toolbox.jl
@@ -1,10 +1,8 @@
-module ToolBox
 using QuadGK, HCubature
-export make_new_dir, coefficients_Vicsek, nice_float2string
 
 """
-Create a new directory `dirname` in the current path. 
-Append a number to the name if the directory already exists. 
+Create a new directory `dirname` in the current path.
+Append a number to the name if the directory already exists.
 """
 function make_new_dir(dirname::String)
     if ispath(dirname)
@@ -33,8 +31,8 @@ end
 
 """
 Return the coefficients `c1,c2,λ` of the SOH model computed for the `model` `"Fokker-Planck"` (default)
-or `"BGK"` with the concentration parameters `κ`. 
-These coefficients are given by 
+or `"BGK"` with the concentration parameters `κ`.
+These coefficients are given by
 
 c₁ = ∫\\_[0,π] cos(θ)exp(κcos(θ))dθ / ∫\\_[0,π] exp(κcos(θ))dθ
 
@@ -42,13 +40,13 @@ c₂ = ∫\\_[0,π] cos(θ)sin(θ)g(θ)exp(κcos(θ))dθ / ∫\\_[0,π] sin(θ)g
 
 λ = 1/κ
 
-where 
+where
 
 g(θ) = θ/κ - π/κ * ∫\\_[0,θ] exp(-κcos(ψ))dψ / ∫\\_[0,π] exp(-κcos(ψ))dψ in the Fokker-Planck case
 
-and 
+and
 
-g(θ) = 1 in the BGK case. 
+g(θ) = 1 in the BGK case.
 """
 function coefficients_Vicsek(κ;model="Fokker-Planck")
     λ = 1/κ
@@ -62,10 +60,10 @@ function coefficients_Vicsek(κ;model="Fokker-Planck")
         return c1,c2,λ
     elseif model=="Fokker-Planck"
         Zinv = quadgk(θ->exp(-κ*cos(θ)),0,pi,rtol=1e-5)[1]
-        I21 = quadgk(θ->θ*cos(θ)*sin(θ)*exp(κ*cos(θ)),0,pi,rtol=1e-5)[1]/κ 
+        I21 = quadgk(θ->θ*cos(θ)*sin(θ)*exp(κ*cos(θ)),0,pi,rtol=1e-5)[1]/κ
         I22 = pi/(κ*Zinv) * hcubature(x->cos(x[1])*sin(x[1])*exp(κ*cos(x[1]))*exp(-κ*cos(x[2]))*(x[2]<x[1]),(0,0),(pi,pi),rtol=1e-3)[1]
         I2 = I21 - I22
-        Z21 = quadgk(θ->θ*sin(θ)*exp(κ*cos(θ)),0,pi,rtol=1e-5)[1]/κ 
+        Z21 = quadgk(θ->θ*sin(θ)*exp(κ*cos(θ)),0,pi,rtol=1e-5)[1]/κ
         Z22 = pi/(κ*Zinv) * hcubature(x->sin(x[1])*exp(κ*cos(x[1]))*exp(-κ*cos(x[2]))*(x[2]<x[1]),(0,0),(pi,pi),rtol=1e-3)[1]
         Z2 = Z21 - Z22
         c2 = I2/Z2
@@ -73,8 +71,4 @@ function coefficients_Vicsek(κ;model="Fokker-Planck")
     else
         ArgumentError("Model not defined!")
     end
-end
-
-
-
 end


### PR DESCRIPTION
Hi Antoine,

I tried out your simulation and it is very impressive! (I also want to turn my simulations into open-source projects, and I took the chance to learn a bit from how you organise your simulation code.)

When playing around with the code, I found a nice way to speed up the simulation (without plots) by roughly a factor of ×1.6 (i.e. 4.79 sec → 2.79 sec on my computer). That's why I made this pull request in case you want to use it.

- First change: The trick is to change the order of the `for` loops to access the arrays in [column-major](https://docs.julialang.org/en/v1/manual/performance-tips/#man-performance-column-major) ordering. (The same trick could actually also improve the FORTRAN code).
  - There might be more places to do that change, so far I only focused on the file `src/scheme.jl`.

- Second change: I also added the commands `@inbounds` and `@simd`, which made it just slightly faster. (Not sure if that is essential.)

- The third change is less essential. 
As far as I know, it is not necessary to add modules for each file, that just adds redundant compilations as included files are compiled several times. 

